### PR TITLE
Fix casting bug in JsonLdSerializer

### DIFF
--- a/src/main/java/com/google/schemaorg/JsonLdSerializer.java
+++ b/src/main/java/com/google/schemaorg/JsonLdSerializer.java
@@ -740,7 +740,7 @@ public class JsonLdSerializer {
                   paramValue = method.invoke(null, java.lang.Float.parseFloat(strValue));
                 } else {
                   Method method = parameterType.getMethod(OF_METHOD_NAME, String.class);
-                  paramValue = method.invoke(null, ((Text) value).getValue());
+                  paramValue = method.invoke(null, ((Number) value).getValue());
                 }
                 break;
               } catch (NoSuchMethodException


### PR DESCRIPTION
The existing cast couldn't possibly succeed, since `value` was known to be of type `Number`, not `Text`.